### PR TITLE
Fix clippy issues

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,8 +2,8 @@
 extern crate test;
 use test::Bencher;
 
-use ndarray_einsum_beta::*;
 use ndarray::prelude::*;
+use ndarray_einsum_beta::*;
 use ndarray_rand::RandomExt;
 use rand::distributions::Uniform;
 

--- a/src/contractors/mod.rs
+++ b/src/contractors/mod.rs
@@ -140,7 +140,7 @@ pub struct SingletonContraction<A> {
 
 impl<A> SingletonContraction<A> {
     pub fn new(sc: &SizedContraction) -> Self {
-        let singleton_summary = SingletonSummary::new(&sc);
+        let singleton_summary = SingletonSummary::new(sc);
         let method = singleton_summary.get_strategy();
 
         SingletonContraction {
@@ -279,15 +279,15 @@ impl<A> PairContraction<A> {
         let output_indices = &sc.contraction.output_indices;
 
         let lhs_simplification = SimplificationMethodAndOutput::from_indices_and_sizes(
-            &lhs_indices,
-            &rhs_indices,
-            &output_indices,
+            lhs_indices,
+            rhs_indices,
+            output_indices,
             sc,
         );
         let rhs_simplification = SimplificationMethodAndOutput::from_indices_and_sizes(
-            &rhs_indices,
-            &lhs_indices,
-            &output_indices,
+            rhs_indices,
+            lhs_indices,
+            output_indices,
             sc,
         );
         let new_lhs_indices = match &lhs_simplification {
@@ -300,7 +300,7 @@ impl<A> PairContraction<A> {
         };
 
         let reduced_sc = sc
-            .subset(&[new_lhs_indices, new_rhs_indices], &output_indices)
+            .subset(&[new_lhs_indices, new_rhs_indices], output_indices)
             .unwrap();
 
         let pair_summary = PairSummary::new(&reduced_sc);
@@ -429,7 +429,7 @@ pub struct EinsumPath<A> {
 
 impl<A> EinsumPath<A> {
     pub fn new(sc: &SizedContraction) -> Self {
-        let contraction_order = generate_optimized_order(&sc, OptimizationMethod::Naive);
+        let contraction_order = generate_optimized_order(sc, OptimizationMethod::Naive);
 
         EinsumPath::from_path(&contraction_order)
     }

--- a/src/contractors/pair_contractors.rs
+++ b/src/contractors/pair_contractors.rs
@@ -61,11 +61,10 @@ fn maybe_find_outputs_in_inputs_unique(
                 .iter()
                 .position(|&input_char| input_char == output_char);
             if input_pos.is_some() {
-                assert!(input_indices
+                assert!(!input_indices
                     .iter()
                     .skip(input_pos.unwrap() + 1)
-                    .position(|&input_char| input_char == output_char)
-                    .is_none());
+                    .any(|&input_char| input_char == output_char));
             }
             input_pos
         })
@@ -258,9 +257,9 @@ impl TensordotGeneral {
             &lhs_shape,
             &rhs_shape,
             lhs_indices,
-            &rhs_indices,
-            &contracted_indices,
-            &output_indices,
+            rhs_indices,
+            contracted_indices,
+            output_indices,
         )
     }
 
@@ -272,15 +271,14 @@ impl TensordotGeneral {
         contracted_indices: &[char],
         output_indices: &[char],
     ) -> Self {
-        let lhs_contracted_axes = find_outputs_in_inputs_unique(&contracted_indices, &lhs_indices);
-        let rhs_contracted_axes = find_outputs_in_inputs_unique(&contracted_indices, &rhs_indices);
+        let lhs_contracted_axes = find_outputs_in_inputs_unique(contracted_indices, lhs_indices);
+        let rhs_contracted_axes = find_outputs_in_inputs_unique(contracted_indices, rhs_indices);
         let mut uncontracted_chars: Vec<char> = lhs_indices
             .iter()
             .filter(|&&input_char| {
                 output_indices
                     .iter()
-                    .position(|&output_char| input_char == output_char)
-                    .is_some()
+                    .any(|&output_char| input_char == output_char)
             })
             .cloned()
             .collect();
@@ -289,17 +287,16 @@ impl TensordotGeneral {
             .filter(|&&input_char| {
                 output_indices
                     .iter()
-                    .position(|&output_char| input_char == output_char)
-                    .is_some()
+                    .any(|&output_char| input_char == output_char)
             })
             .cloned()
             .collect();
         uncontracted_chars.append(&mut rhs_uncontracted_chars);
-        let output_order = find_outputs_in_inputs_unique(&output_indices, &uncontracted_chars);
+        let output_order = find_outputs_in_inputs_unique(output_indices, &uncontracted_chars);
 
         TensordotGeneral::from_shapes_and_axis_numbers(
-            &lhs_shape,
-            &rhs_shape,
+            lhs_shape,
+            rhs_shape,
             &lhs_contracted_axes,
             &rhs_contracted_axes,
             &output_order,
@@ -364,7 +361,7 @@ impl TensordotGeneral {
                 num_contracted_axes,
             );
 
-        let output_permutation = Permutation::from_indices(&output_order);
+        let output_permutation = Permutation::from_indices(output_order);
 
         TensordotGeneral {
             lhs_permutation,
@@ -532,7 +529,7 @@ impl<A> PairContractor<A> for ScalarMatrixProduct {
         'c: 'd,
         A: Clone + LinalgScalar,
     {
-        let lhs_0d: A = lhs.first().unwrap().clone();
+        let lhs_0d: A = *lhs.first().unwrap();
         rhs.mapv(|x| x * lhs_0d)
     }
 }
@@ -631,7 +628,7 @@ impl<A> PairContractor<A> for MatrixScalarProduct {
         'c: 'd,
         A: Clone + LinalgScalar,
     {
-        let rhs_0d: A = rhs.first().unwrap().clone();
+        let rhs_0d: A = *rhs.first().unwrap();
         lhs.mapv(|x| x * rhs_0d)
     }
 }
@@ -720,26 +717,18 @@ impl BroadcastProductGeneral {
         let rhs_indices = &sc.contraction.operand_indices[1];
         let output_indices = &sc.contraction.output_indices;
 
-        let maybe_lhs_indices = maybe_find_outputs_in_inputs_unique(&output_indices, &lhs_indices);
-        let maybe_rhs_indices = maybe_find_outputs_in_inputs_unique(&output_indices, &rhs_indices);
-        let lhs_indices: Vec<usize> = maybe_lhs_indices
-            .iter()
-            .filter(|x| x.is_some())
-            .map(|x| x.unwrap())
-            .collect();
-        let rhs_indices: Vec<usize> = maybe_rhs_indices
-            .iter()
-            .filter(|x| x.is_some())
-            .map(|x| x.unwrap())
-            .collect();
+        let maybe_lhs_indices = maybe_find_outputs_in_inputs_unique(output_indices, lhs_indices);
+        let maybe_rhs_indices = maybe_find_outputs_in_inputs_unique(output_indices, rhs_indices);
+        let lhs_indices: Vec<usize> = maybe_lhs_indices.iter().copied().flatten().collect();
+        let rhs_indices: Vec<usize> = maybe_rhs_indices.iter().copied().flatten().collect();
         let lhs_insertions: Vec<usize> = maybe_lhs_indices
-            .iter()
+            .into_iter()
             .enumerate()
             .filter(|(_, x)| x.is_none())
             .map(|(i, _)| i)
             .collect();
         let rhs_insertions: Vec<usize> = maybe_rhs_indices
-            .iter()
+            .into_iter()
             .enumerate()
             .filter(|(_, x)| x.is_none())
             .map(|(i, _)| i)
@@ -834,8 +823,8 @@ impl StackedTensordotGeneral {
         let rhs_indices = &sc.contraction.operand_indices[1];
         let output_indices = &sc.contraction.output_indices;
 
-        let maybe_lhs_axes = maybe_find_outputs_in_inputs_unique(&output_indices, &lhs_indices);
-        let maybe_rhs_axes = maybe_find_outputs_in_inputs_unique(&output_indices, &rhs_indices);
+        let maybe_lhs_axes = maybe_find_outputs_in_inputs_unique(output_indices, lhs_indices);
+        let maybe_rhs_axes = maybe_find_outputs_in_inputs_unique(output_indices, rhs_indices);
         let mut lhs_stack_axes = Vec::new();
         let mut rhs_stack_axes = Vec::new();
         let mut stack_indices = Vec::new();
@@ -883,9 +872,9 @@ impl StackedTensordotGeneral {
         }
 
         for (lhs_pos, &lhs_char) in lhs_indices.iter().enumerate() {
-            if let None = output_indices
+            if !output_indices
                 .iter()
-                .position(|&output_char| output_char == lhs_char)
+                .any(|&output_char| output_char == lhs_char)
             {
                 // Contracted index
                 lhs_contracted_axes.push(lhs_pos);
@@ -931,7 +920,7 @@ impl StackedTensordotGeneral {
             intermediate_shape.push(sc.output_size[rhs_char]);
         }
 
-        let output_order = find_outputs_in_inputs_unique(&output_indices, &intermediate_indices);
+        let output_order = find_outputs_in_inputs_unique(output_indices, &intermediate_indices);
         let output_shape = intermediate_indices
             .iter()
             .map(|c| sc.output_size[c])

--- a/src/contractors/singleton_contractors.rs
+++ b/src/contractors/singleton_contractors.rs
@@ -130,7 +130,6 @@ impl<A> SingletonContractor<A> for Permutation {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Summation {
-    orig_axis_list: Vec<usize>,
     adjusted_axis_list: Vec<usize>,
 }
 
@@ -147,13 +146,9 @@ impl Summation {
 
     fn from_sizes(start_index: usize, num_summed_axes: usize) -> Self {
         assert!(num_summed_axes >= 1);
-        let orig_axis_list = (start_index..(start_index + num_summed_axes)).collect();
         let adjusted_axis_list = (0..num_summed_axes).map(|_| start_index).collect();
 
-        Summation {
-            orig_axis_list,
-            adjusted_axis_list,
-        }
+        Summation { adjusted_axis_list }
     }
 }
 
@@ -243,7 +238,7 @@ impl<A> SingletonViewer<A> for Diagonalization {
         let data_slice = tensor.as_slice_memory_order().unwrap();
         ArrayView::from_shape(
             IxDyn(&self.output_shape).strides(IxDyn(&strides)),
-            &data_slice,
+            data_slice,
         )
         .unwrap()
     }
@@ -285,11 +280,11 @@ impl PermutationAndSummation {
             output_order.push(input_pos);
         }
         for (i, &input_char) in sc.contraction.operand_indices[0].iter().enumerate() {
-            if let None = sc
+            if !sc
                 .contraction
                 .output_indices
                 .iter()
-                .position(|&output_char| output_char == input_char)
+                .any(|&output_char| output_char == input_char)
             {
                 output_order.push(i);
             }

--- a/src/contractors/strategies.rs
+++ b/src/contractors/strategies.rs
@@ -52,7 +52,7 @@ impl SingletonSummary {
         let output_indices = &sc.contraction.output_indices;
         let input_indices = &sc.contraction.operand_indices[0];
 
-        SingletonSummary::from_indices(&input_indices, &output_indices)
+        SingletonSummary::from_indices(input_indices, output_indices)
     }
 
     fn from_indices(input_indices: &[char], output_indices: &[char]) -> Self {
@@ -123,7 +123,7 @@ impl PairSummary {
         let lhs_indices = &sc.contraction.operand_indices[0];
         let rhs_indices = &sc.contraction.operand_indices[1];
 
-        PairSummary::from_indices(&lhs_indices, &rhs_indices, &output_indices)
+        PairSummary::from_indices(lhs_indices, rhs_indices, output_indices)
     }
 
     fn from_indices(lhs_indices: &[char], rhs_indices: &[char], output_indices: &[char]) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,8 +284,8 @@ where
     let rhs_axes_copy: Vec<_> = rhs_axes.iter().map(|x| x.index()).collect();
     let output_order: Vec<usize> = (0..(lhs.ndim() + rhs.ndim() - 2 * (lhs_axes.len()))).collect();
     let tensordotter = TensordotGeneral::from_shapes_and_axis_numbers(
-        &lhs.shape(),
-        &rhs.shape(),
+        lhs.shape(),
+        rhs.shape(),
         &lhs_axes_copy,
         &rhs_axes_copy,
         &output_order,

--- a/src/optimizers.rs
+++ b/src/optimizers.rs
@@ -253,7 +253,7 @@ fn generate_path(sized_contraction: &SizedContraction, tensor_order: &[usize]) -
                 // Phew, now make the mini-contraction.
                 let sc = generate_sized_contraction_pair(
                     &lhs_indices,
-                    &rhs_indices,
+                    rhs_indices,
                     &output_indices,
                     &permuted_contraction,
                 );

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -132,19 +132,19 @@ impl Contraction {
             }
 
             // Must be in inputs
-            if input_char_counts.get(&c).is_none() {
+            if !input_char_counts.contains_key(&c) {
                 return Err("Requested output contains an index not found in inputs");
             }
         }
 
         let mut summation_indices: Vec<char> = input_char_counts
             .keys()
-            .filter(|&c| distinct_output_indices.get(c).is_none())
+            .filter(|&c| !distinct_output_indices.contains_key(c))
             .cloned()
             .collect();
         summation_indices.sort();
 
-        let cloned_operand_indices: Vec<Vec<char>> = operand_indices.iter().cloned().collect();
+        let cloned_operand_indices: Vec<Vec<char>> = operand_indices.to_vec();
 
         Ok(Contraction {
             operand_indices: cloned_operand_indices,
@@ -244,7 +244,7 @@ impl SizedContraction {
             .collect();
         if all_operand_indices
             .iter()
-            .any(|c| self.output_size.get(c).is_none())
+            .any(|c| !self.output_size.contains_key(c))
         {
             return Err("Character found in new_operand_indices but not in self.output_size");
         }
@@ -270,7 +270,7 @@ impl SizedContraction {
         contraction: &Contraction,
         operand_shapes: &[Vec<usize>],
     ) -> Result<Self, &'static str> {
-        let output_size = OutputSize::from_contraction_and_shapes(&contraction, operand_shapes)?;
+        let output_size = OutputSize::from_contraction_and_shapes(contraction, operand_shapes)?;
 
         Ok(SizedContraction {
             contraction: contraction.clone(),
@@ -358,7 +358,7 @@ impl SizedContraction {
         &self,
         operands: &[&dyn ArrayLike<A>],
     ) -> ArrayD<A> {
-        let cpc = EinsumPath::new(&self);
+        let cpc = EinsumPath::new(self);
         cpc.contract_operands(operands)
     }
 
@@ -373,12 +373,12 @@ impl SizedContraction {
     /// assert_eq!(sc.as_einsum_string(), "ij,jk->ik");
     /// ```
     pub fn as_einsum_string(&self) -> String {
-        assert!(self.contraction.operand_indices.len() > 0);
+        assert!(!self.contraction.operand_indices.is_empty());
         let mut s: String = self.contraction.operand_indices[0]
             .iter()
             .cloned()
             .collect();
-        for op in (&self.contraction.operand_indices[1..]).iter() {
+        for op in self.contraction.operand_indices[1..].iter() {
             s.push(',');
             for &c in op.iter() {
                 s.push(c);
@@ -410,13 +410,13 @@ fn parse_einsum_string(input_string: &str) -> Option<EinsumParse> {
     let output_indices = captures.name("output").map(|s| String::from(s.as_str()));
 
     operand_indices.push(String::from(&captures["first_operand"]));
-    for s in (&captures["more_operands"]).split(',').skip(1) {
+    for s in captures["more_operands"].split(',').skip(1) {
         operand_indices.push(String::from(s));
     }
 
     Some(EinsumParse {
-        operand_indices: operand_indices,
-        output_indices: output_indices,
+        operand_indices,
+        output_indices,
     })
 }
 


### PR DESCRIPTION
This commit goes through the code base and fixes issues identified by cargo with Rust 1.84 (the latest release). One change clippy is recommending which I did not make was changing the signature of: `into_dyn_view` to take ownership of self instead of a borrow because that has API implications and it felt out of place in a largely mechanical PR.